### PR TITLE
Fix deprecation warning on JSON::PullParser

### DIFF
--- a/src/money/currency/json.cr
+++ b/src/money/currency/json.cr
@@ -19,7 +19,7 @@ class Money::Currency
 
   def self.new(pull : JSON::PullParser)
     case pull.kind
-    when :string
+    when JSON::PullParser::Kind::String
       find(pull.read_string)
     else
       previous_def

--- a/src/money/money/json.cr
+++ b/src/money/money/json.cr
@@ -15,7 +15,7 @@ struct Money
 
   def self.new(pull : JSON::PullParser)
     case pull.kind
-    when :string
+    when JSON::PullParser::Kind::String
       parse(pull.read_string)
     else
       previous_def


### PR DESCRIPTION
This fixes #5. However, there are quite a few failing specs:

```
Finished in 54.11 milliseconds
203 examples, 17 failures, 1 errors, 0 pending

Failed examples:

crystal spec spec/money/allocate_spec.cr:35 # Money::Allocate #allocate negative amount does not lose pennies
crystal spec spec/money/allocate_spec.cr:40 # Money::Allocate #allocate negative amount allocates the same way as positive amounts
crystal spec spec/money/allocate_spec.cr:59 # Money::Allocate #split gives 1 cent to both people if we start with 2
crystal spec spec/money/allocate_spec.cr:64 # Money::Allocate #split may distribute no money to some parties if there isn't enough to go around
crystal spec spec/money/allocate_spec.cr:69 # Money::Allocate #split does not lose pennies
crystal spec spec/money/allocate_spec.cr:74 # Money::Allocate #split splits a dollar
crystal spec spec/money/arithmetic_spec.cr:182 # Money::Arithmetic #/ divides Money by Money (different currency) and returns Float
crystal spec spec/money/arithmetic_spec.cr:203 # Money::Arithmetic #divmod calculates division and modulo with Integer
crystal spec spec/money/arithmetic_spec.cr:215 # Money::Arithmetic #divmod calculates division and modulo with Money (same currency)
crystal spec spec/money/arithmetic_spec.cr:227 # Money::Arithmetic #divmod calculates division and modulo with Money (different currency)
crystal spec spec/money/arithmetic_spec.cr:248 # Money::Arithmetic #modulo calculates modulo with Integer
crystal spec spec/money/arithmetic_spec.cr:260 # Money::Arithmetic #modulo calculates modulo with Money (same currency)
crystal spec spec/money/arithmetic_spec.cr:272 # Money::Arithmetic #modulo calculates modulo with Money (different currency)
crystal spec spec/money/arithmetic_spec.cr:293 # Money::Arithmetic #remainder calculates remainder with Integer
crystal spec spec/money/arithmetic_spec.cr:325 # Money::Arithmetic #round with Money.infinite_precision = true returns rounded value with given precision
crystal spec spec/money_spec.cr:163 # Money #nearest_cash_value rounds to the nearest possible cash value
crystal spec spec/money_spec.cr:202 # Money #rounded_to_nearest_cash_value rounds to the nearest possible cash value
crystal spec spec/money_spec.cr:264 # Money #hash= can be used to return the intersection of Money object arrays
```

Most of them are related I think, because they have similar failures:

```
1) Money::Allocate #allocate negative amount does not lose pennies
     Failure/Error: moneys.map(&.cents).should eq [-34, -33, -33]

       Expected: [-34, -33, -33]
            got: [-33700, -33600, -33600]

     # spec/money/allocate_spec.cr:37
```

