### PR TITLE
Stop setting `USD` as default currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ major_currencies(Money::Currency)
 
 ### Default Currency
 
-By default, `Money` uses `USD`. You can change it:
+By default, `Money` does not have a default currency. You can set it like so:
 
 ```crystal
 Money.default_currency = :xag

--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -41,8 +41,37 @@ describe Money::Context do
   end
 
   describe "#default_currency" do
-    it "is set to `USD` by default" do
-      subject.default_currency.should eq Money::Currency.find("USD")
+    it "raises UndefinedCurrencyError by default" do
+      expect_raises(Money::UndefinedCurrencyError) { subject.default_currency }
+    end
+
+    context "allows setting the default currency" do
+      context = Money::Context.new
+
+      it "by Currency" do
+        context.default_currency = Money::Currency.find("PLN")
+        context.default_currency.should be_a Money::Currency
+        context.default_currency.should eq Money::Currency.find("PLN")
+      end
+
+      it "by String" do
+        context.default_currency = "EUR"
+        context.default_currency.should be_a Money::Currency
+        context.default_currency.should eq Money::Currency.find("EUR")
+      end
+
+      it "by Symbol" do
+        context.default_currency = :xag
+        context.default_currency.should be_a Money::Currency
+        context.default_currency.should eq Money::Currency.find("XAG")
+      end
+
+      it "by Nil" do
+        context.default_currency = nil
+        expect_raises(Money::UndefinedCurrencyError, "No default currency set") do
+          context.default_currency
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -33,3 +33,10 @@ def with_default_exchange(exchange = nil, &)
     Money.default_exchange = previous_exchange
   end
 end
+
+Spec.around_each do |example|
+  Money.default_currency = "USD"
+  example.run
+ensure
+  Money.default_currency = nil
+end

--- a/src/money/context.cr
+++ b/src/money/context.cr
@@ -35,11 +35,16 @@ struct Money
     property rounding_mode : Number::RoundingMode = :ties_away
 
     # Default currency for creating new `Money` object.
-    property default_currency : Currency { Currency.find("USD") }
+    # Raises `UndefinedCurrencyError` if not set.
+    property default_currency : Currency { raise UndefinedCurrencyError.new }
 
     # :ditto:
     def default_currency=(currency_code : String | Symbol)
       self.default_currency = Currency.find(currency_code)
+    end
+
+    # :ditto:
+    def default_currency=(@default_currency : Nil)
     end
 
     # Each `Money` object is associated to a currency exchange object.

--- a/src/money/error.cr
+++ b/src/money/error.cr
@@ -38,6 +38,13 @@ struct Money
     end
   end
 
+  # Raised when `Money.default_currency` is not set.
+  class UndefinedCurrencyError < Error
+    def initialize
+      super("No default currency set")
+    end
+  end
+
   # Raised when trying to find an unknown currency.
   class UnknownCurrencyError < Error
     def initialize(key)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that no default currency is set by default and users must explicitly set one if desired.

* **New Features**
  * Introduced a new error message when accessing the default currency without setting it.

* **Bug Fixes**
  * Improved error handling to raise an explicit error if the default currency is not set, instead of assuming "USD".

* **Tests**
  * Enhanced test coverage to verify explicit default currency behavior and error handling.
  * Ensured consistent test setup and teardown for default currency state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->