### PR TITLE
Remove `Money#exchange` property

### DIFF
--- a/spec/core_ext/to_money_spec.cr
+++ b/spec/core_ext/to_money_spec.cr
@@ -6,14 +6,6 @@ describe String do
       "10.00 USD".to_money?.should eq Money.from_amount(10, "USD")
     end
 
-    it "returns a Money object with given exchange" do
-      exchange =
-        Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
-
-      money = "10.00 USD".to_money?(exchange).should_not be_nil
-      money.exchange.should be exchange
-    end
-
     context "when :allow_ambiguous is true (default)" do
       it "returns a first matching currency for ambiguous values" do
         "$10.00".to_money?.should eq Money.from_amount(10, "USD")
@@ -34,14 +26,6 @@ describe String do
   describe "#to_money" do
     it "returns a Money object" do
       "10.00 USD".to_money.should eq Money.from_amount(10, "USD")
-    end
-
-    it "returns a Money object with given exchange" do
-      exchange =
-        Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
-
-      "10.00 USD".to_money(exchange).exchange
-        .should be exchange
     end
 
     context "when :allow_ambiguous is true (default)" do
@@ -78,14 +62,6 @@ describe Number do
       111.to_money?("PLN").should eq Money.from_amount(111, "PLN")
     end
 
-    it "returns a Money object with given exchange" do
-      exchange =
-        Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
-
-      money = 111.to_money?(exchange: exchange).should_not be_nil
-      money.exchange.should be exchange
-    end
-
     it "returns `nil` for invalid values" do
       Float64::INFINITY.to_money?.should be_nil
       Float64::NAN.to_money?.should be_nil
@@ -101,14 +77,6 @@ describe Number do
 
     it "returns a Money object with given currency" do
       111.to_money("PLN").should eq Money.from_amount(111, "PLN")
-    end
-
-    it "returns a Money object with given exchange" do
-      exchange =
-        Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
-
-      111.to_money(exchange: exchange).exchange
-        .should be exchange
     end
 
     it "raises ArgumentError for invalid values" do

--- a/spec/money/arithmetic_spec.cr
+++ b/spec/money/arithmetic_spec.cr
@@ -69,7 +69,7 @@ describe Money::Arithmetic do
       exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
       exchange.rate_store["EUR", "USD"] = 10
 
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         (Money.new(10_00, "USD") + Money.new(90, "EUR")).should eq Money.new(19_00, "USD")
       end
     end
@@ -89,7 +89,7 @@ describe Money::Arithmetic do
       exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
       exchange.rate_store["EUR", "USD"] = 10
 
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         (Money.new(10_00, "USD") - Money.new(90, "EUR")).should eq Money.new(1_00, "USD")
       end
     end
@@ -138,7 +138,7 @@ describe Money::Arithmetic do
       exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
       exchange.rate_store["EUR", "USD"] = 2
 
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         tests = {
           {a: Money.new(13, "USD"), b: Money.new(4, "EUR"), c: 1.625},
           {a: Money.new(13, "USD"), b: Money.new(-4, "EUR"), c: -1.625},
@@ -181,7 +181,7 @@ describe Money::Arithmetic do
       exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
       exchange.rate_store["EUR", "USD"] = 2
 
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         tests = {
           {a: Money.new(13, "USD"), b: Money.new(4, "EUR"), c: {1, Money.new(5, "USD")}},
           {a: Money.new(13, "USD"), b: Money.new(-4, "EUR"), c: {-2, Money.new(-3, "USD")}},
@@ -224,7 +224,7 @@ describe Money::Arithmetic do
       exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
       exchange.rate_store["EUR", "USD"] = 2
 
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         tests = {
           {a: Money.new(13, "USD"), b: Money.new(4, "EUR"), c: Money.new(5, "USD")},
           {a: Money.new(13, "USD"), b: Money.new(-4, "EUR"), c: Money.new(-3, "USD")},

--- a/spec/money/constructors_spec.cr
+++ b/spec/money/constructors_spec.cr
@@ -65,20 +65,6 @@ describe Money::Constructors do
         end
       end
     end
-
-    context "given a exchange is not provided" do
-      it "should return the default exchange" do
-        Money.new.exchange.should be Money.default_exchange
-      end
-    end
-
-    context "given a exchange is provided" do
-      exchange = Money::Currency::Exchange::SingleCurrency.new
-
-      it "should return given exchange" do
-        Money.new(exchange: exchange).exchange.should be exchange
-      end
-    end
   end
 
   describe ".from_amount" do
@@ -146,19 +132,9 @@ describe Money::Constructors do
       Money.zero.should eq Money.new(0)
     end
 
-    it "uses default Currency::Exchange object" do
-      Money.zero.exchange.should be Money.default_exchange
-    end
-
     it "uses given Currency object" do
       Money::Currency.find("EUR").tap do |currency|
         Money.zero(currency: currency).currency.should be currency
-      end
-    end
-
-    it "uses given Currency::Exchange object" do
-      Money::Currency::Exchange::SingleCurrency.new.tap do |exchange|
-        Money.zero(exchange: exchange).exchange.should be exchange
       end
     end
   end

--- a/spec/money/exchange_spec.cr
+++ b/spec/money/exchange_spec.cr
@@ -12,23 +12,21 @@ describe Money::Exchange do
     end
 
     it "exchanges the amount properly" do
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         Money.new(100_00, "EUR").exchange_to("USD").should eq Money.new(123_00, "USD")
         Money.new(100_00, "USD").exchange_to("EUR").should eq Money.new(321_00, "EUR")
       end
     end
 
     it "returns self when the currencies are the same" do
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         money = Money.new(1, "USD")
         money.exchange_to("USD").should eq money
       end
     end
 
     it "does not exchange when the amount is zero" do
-      with_default_exchange do
-        Money.disallow_currency_conversion!
-
+      Money.with_default_exchange(Money::Currency::Exchange::SingleCurrency.new) do
         Money.zero("USD").exchange_to("EUR")
           .should eq Money.zero("EUR")
       end
@@ -37,7 +35,7 @@ describe Money::Exchange do
 
   describe "#with_same_currency" do
     it "yields the other object exchanged to self.currency" do
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         Money.zero("USD").with_same_currency(Money.new(100_00, "EUR")) do |other|
           other.should eq Money.new(123_00, "USD")
         end

--- a/spec/money/exchange_spec.cr
+++ b/spec/money/exchange_spec.cr
@@ -6,6 +6,11 @@ describe Money::Exchange do
   exchange.rate_store["USD", "EUR"] = 3.21
 
   describe "#exchange_to" do
+    it "exchanges the amount properly with given exchange" do
+      Money.new(100_00, "EUR").exchange_to("USD", exchange).should eq Money.new(123_00, "USD")
+      Money.new(100_00, "USD").exchange_to("EUR", exchange).should eq Money.new(321_00, "EUR")
+    end
+
     it "exchanges the amount properly" do
       with_default_exchange(exchange) do
         Money.new(100_00, "EUR").exchange_to("USD").should eq Money.new(123_00, "USD")

--- a/spec/money_spec.cr
+++ b/spec/money_spec.cr
@@ -82,7 +82,7 @@ describe Money do
 
     it "sets the value to the given Currency::Exchange object" do
       exchange = Money::Currency::Exchange::SingleCurrency.new
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         Money.default_exchange.should be exchange
       end
     end
@@ -127,24 +127,20 @@ describe Money do
 
   describe ".without_currency_conversion" do
     it "disallows conversions within the yielded block" do
-      with_default_exchange do
-        prev_exchange = Money.default_exchange
+      prev_exchange = Money.default_exchange
 
-        Money.without_currency_conversion do
-          expect_raises(Money::DifferentCurrencyError) do
-            Money.new(100, "USD") + Money.new(100, "EUR")
-          end
+      Money.without_currency_conversion do
+        expect_raises(Money::DifferentCurrencyError) do
+          Money.new(100, "USD") + Money.new(100, "EUR")
         end
-        Money.default_exchange.should eq prev_exchange
       end
+      Money.default_exchange.should eq prev_exchange
     end
   end
 
   describe ".disallow_currency_conversion!" do
     it "disallows conversions when doing money arithmetic" do
-      with_default_exchange do
-        Money.disallow_currency_conversion!
-
+      Money.with_default_exchange(Money::Currency::Exchange::SingleCurrency.new) do
         expect_raises(Money::DifferentCurrencyError) do
           Money.new(100, "USD") + Money.new(100, "EUR")
         end
@@ -181,7 +177,7 @@ describe Money do
     end
 
     it "returns true if converted amount is equal" do
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         (Money.new(2_00, "USD") =~ Money.new(1_00, "EUR")).should be_true
         (Money.new(6_00, "USD") =~ Money.new(1_00, "EUR")).should be_false
       end
@@ -204,7 +200,7 @@ describe Money do
     end
 
     it "converts other object amount to current currency, then compares the two object amounts (different currency)" do
-      with_default_exchange(exchange) do
+      Money.with_default_exchange(exchange) do
         (Money.new(150_00, "USD") <=> Money.new(100_00, "EUR")).should eq 0
         (Money.new(200_00, "USD") <=> Money.new(200_00, "EUR")).should be < 0
         (Money.new(800_00, "USD") <=> Money.new(400_00, "EUR")).should be > 0
@@ -221,8 +217,7 @@ describe Money do
       context "when currencies differ" do
         context "when both values are 1_00" do
           it "raises currency error" do
-            with_default_exchange do
-              Money.disallow_currency_conversion!
+            Money.with_default_exchange(Money::Currency::Exchange::SingleCurrency.new) do
               expect_raises(Money::DifferentCurrencyError) do
                 Money.us_dollar(1_00) <=> Money.euro(1_00)
               end
@@ -232,8 +227,7 @@ describe Money do
 
         context "when both values are 0" do
           it "considers them equal" do
-            with_default_exchange do
-              Money.disallow_currency_conversion!
+            Money.with_default_exchange(Money::Currency::Exchange::SingleCurrency.new) do
               (Money.us_dollar(0) <=> Money.euro(0)).should eq 0
             end
           end

--- a/spec/money_spec.cr
+++ b/spec/money_spec.cr
@@ -163,11 +163,6 @@ describe Money do
   end
 
   describe "#==" do
-    it "returns true even if exchange differs" do
-      Money.new(1_00, "USD", Money::Currency::Exchange.new)
-        .should eq Money.new(1_00, "USD", Money::Currency::Exchange.new)
-    end
-
     it "returns true if amounts and currencies are equal" do
       Money.new(1_00, "USD").should eq Money.new(1_00, "USD")
       Money.new(1_00, "USD").should_not eq Money.new(5_00, "USD")
@@ -178,11 +173,6 @@ describe Money do
   describe "#=~" do
     exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
     exchange.rate_store["EUR", "USD"] = 2
-
-    it "returns true even if exchange differs" do
-      (Money.new(1_00, "USD", Money::Currency::Exchange.new) =~
-        Money.new(1_00, "USD", Money::Currency::Exchange.new)).should be_true
-    end
 
     it "returns true if both amounts are zero, even if currency differs" do
       (Money.zero("USD") =~ Money.zero("USD")).should be_true
@@ -280,24 +270,6 @@ describe Money do
       Money.new(1_00, "EUR").copy_with(fractional: 3_00)
         .should eq Money.new(3_00, "EUR")
     end
-
-    it "copies the exchange" do
-      exchange = Money::Currency::Exchange.new(Money::Currency::RateStore::Memory.new)
-
-      money = Money.new(1_00, "EUR", exchange)
-      money.exchange.should be exchange
-
-      money.copy_with(fractional: 3_00).exchange
-        .should be exchange
-    end
-
-    it "does not materialize the `exchange` property" do
-      money = Money.new(1_00, "EUR")
-      money.@exchange.should be_nil
-
-      money.copy_with(fractional: 3_00).@exchange
-        .should be_nil
-    end
   end
 
   describe "#with_currency" do
@@ -312,7 +284,6 @@ describe Money do
 
       new_money.should eq Money.new(10_00, "EUR")
       new_money.amount.should eq money.amount
-      new_money.exchange.should eq money.exchange
     end
   end
 
@@ -379,27 +350,6 @@ describe Money do
 
     it "returns Currency object passed in #initialize" do
       Money.new(currency: "EUR").currency.should be Money::Currency.find("EUR")
-    end
-  end
-
-  describe "#exchange" do
-    it "returns default Currency::Exchange object" do
-      Money.new.exchange.should be Money.default_exchange
-    end
-
-    it "returns Currency::Exchange object passed in #initialize" do
-      Money::Currency::Exchange::SingleCurrency.new.tap do |exchange|
-        Money.new(exchange: exchange).exchange.should be exchange
-      end
-    end
-
-    it "takes Currency::Exchange object" do
-      Money::Currency::Exchange::SingleCurrency.new.tap do |exchange|
-        Money.new.tap do |money|
-          money.exchange = exchange
-          money.exchange.should be exchange
-        end
-      end
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -24,16 +24,6 @@ ensure
   end
 end
 
-def with_default_exchange(exchange = nil, &)
-  previous_exchange = Money.default_exchange
-  begin
-    Money.default_exchange = exchange if exchange
-    yield
-  ensure
-    Money.default_exchange = previous_exchange
-  end
-end
-
 Spec.around_each do |example|
   Money.default_currency = "USD"
   example.run

--- a/src/core_ext/to_money.cr
+++ b/src/core_ext/to_money.cr
@@ -2,19 +2,15 @@ class String
   # Returns a `Money` instance parsed from `self` if possible, `nil` otherwise.
   #
   # See also `Money.parse?`.
-  def to_money?(exchange = nil, *, allow_ambiguous = true) : Money?
-    money = Money.parse?(self, allow_ambiguous: allow_ambiguous)
-    money.exchange = exchange if exchange && money
-    money
+  def to_money?(*, allow_ambiguous = true) : Money?
+    Money.parse?(self, allow_ambiguous: allow_ambiguous)
   end
 
   # Returns a `Money` instance parsed from `self`.
   #
   # See also `Money.parse`.
-  def to_money(exchange = nil, *, allow_ambiguous = true) : Money
-    money = Money.parse(self, allow_ambiguous: allow_ambiguous)
-    money.exchange = exchange if exchange
-    money
+  def to_money(*, allow_ambiguous = true) : Money
+    Money.parse(self, allow_ambiguous: allow_ambiguous)
   end
 end
 
@@ -22,14 +18,14 @@ struct Number
   # Returns a `Money` instance parsed from `self` if possible, `nil` otherwise.
   #
   # See also `Money.from_amount`.
-  def to_money?(currency = Money.default_currency, exchange = nil) : Money?
-    Money.from_amount(self, currency, exchange) rescue nil
+  def to_money?(currency = Money.default_currency) : Money?
+    Money.from_amount(self, currency) rescue nil
   end
 
   # Returns a `Money` instance parsed from `self`.
   #
   # See also `Money.from_amount`.
-  def to_money(currency = Money.default_currency, exchange = nil) : Money
-    Money.from_amount(self, currency, exchange)
+  def to_money(currency = Money.default_currency) : Money
+    Money.from_amount(self, currency)
   end
 end

--- a/src/money/currency/exchange.cr
+++ b/src/money/currency/exchange.cr
@@ -63,7 +63,7 @@ class Money::Currency
       amount =
         from.amount * exchange_rate(from.currency, to)
 
-      Money.new(amount: amount, currency: to, exchange: self)
+      Money.new(amount: amount, currency: to)
     end
 
     # Returns the exchange rate between *base* and *target* currency,

--- a/src/money/money.cr
+++ b/src/money/money.cr
@@ -96,6 +96,19 @@ struct Money
     end
   end
 
+  # Sets the given currency *exchange* within the lifetime of the given block.
+  #
+  # See also `Money.default_exchange`.
+  def self.with_default_exchange(exchange : Currency::Exchange, &)
+    prev_default_exchange = default_exchange
+    self.default_exchange = exchange
+    begin
+      yield
+    ensure
+      self.default_exchange = prev_default_exchange
+    end
+  end
+
   # Disallows currency conversion within the lifetime of the given block.
   #
   # See also `Money.disallow_currency_conversion!`.

--- a/src/money/money.cr
+++ b/src/money/money.cr
@@ -122,11 +122,10 @@ struct Money
   # Money.new(0, "USD")    # => Money(@amount=0.0 @currency="USD")
   # Money.new(1_50, "USD") # => Money(@amount=1.5 @currency="USD")
   # ```
-  def self.new(value : Int = 0, currency = Money.default_currency, exchange = nil)
+  def self.new(value : Int = 0, currency = Money.default_currency)
     new(
       fractional: value,
       currency: currency,
-      exchange: exchange,
     )
   end
 
@@ -141,11 +140,10 @@ struct Money
   # WARNING: Floating points cannot guarantee precision. Therefore, they
   # should only be used when you no longer need to represent currency or
   # working with another system that requires floats.
-  def self.new(value : Number, currency = Money.default_currency, exchange = nil)
+  def self.new(value : Number, currency = Money.default_currency)
     new(
       amount: value,
       currency: currency,
-      exchange: exchange,
     )
   end
 
@@ -155,28 +153,15 @@ struct Money
   # The money's currency.
   getter currency : Currency
 
-  # The `Currency::Exchange` object which currency exchanges are performed with.
-  #
-  # NOTE: Will return `Money.default_exchange` if set to `nil` (the default).
-  if_defined?(:JSON) { @[JSON::Field(ignore: true)] }
-  if_defined?(:YAML) { @[YAML::Field(ignore: true)] }
-  property exchange : Currency::Exchange?
-
-  # :ditto:
-  def exchange : Currency::Exchange
-    @exchange || Money.default_exchange
-  end
-
   # Creates a new `Money` object of value given as an *amount*
   # of the given *currency*.
   #
   # ```
   # Money.new(amount: 13.37) # => Money(@amount=13.37)
   # ```
-  def initialize(*, amount : Number, currency = Money.default_currency, exchange = nil)
+  def initialize(*, amount : Number, currency = Money.default_currency)
     @currency = Currency[currency]
     @amount = amount.to_big_d
-    @exchange = exchange
   end
 
   # Creates a new `Money` object of value given as a *fractional*
@@ -185,17 +170,16 @@ struct Money
   # ```
   # Money.new(fractional: 13_37) # => Money(@amount=13.37)
   # ```
-  def initialize(*, fractional : Number, currency = Money.default_currency, exchange = nil)
+  def initialize(*, fractional : Number, currency = Money.default_currency)
     @currency = Currency[currency]
     @amount = fractional.to_big_d / @currency.subunit_to_unit
-    @exchange = exchange
   end
 
-  # Returns a new `Money` instance with same `currency` and `exchange`
-  # properties set as in `self`.
+  # Returns a new `Money` instance with same `currency` property set
+  # as in `self`.
   protected def copy_with(**options) : Money
     options =
-      {currency: @currency, exchange: @exchange}.merge(options)
+      {currency: @currency}.merge(options)
 
     Money.new(**options)
   end

--- a/src/money/money/constructors.cr
+++ b/src/money/money/constructors.cr
@@ -9,11 +9,10 @@ struct Money
     # ```
     #
     # See also `#initialize`.
-    def from_amount(amount : Number | String, currency = Money.default_currency, exchange = nil) : Money
+    def from_amount(amount : Number | String, currency = Money.default_currency) : Money
       new(
         amount: amount.to_big_d,
         currency: currency,
-        exchange: exchange,
       )
     end
 
@@ -26,11 +25,10 @@ struct Money
     # ```
     #
     # See also `#initialize`.
-    def from_fractional(fractional : Number | String, currency = Money.default_currency, exchange = nil) : Money
+    def from_fractional(fractional : Number | String, currency = Money.default_currency) : Money
       new(
         fractional: fractional.to_big_d,
         currency: currency,
-        exchange: exchange,
       )
     end
 
@@ -40,8 +38,8 @@ struct Money
     # Money.zero       # => Money(@amount=0.0)
     # Money.zero(:pln) # => Money(@amount=0.0 @currency="PLN")
     # ```
-    def zero(currency = Money.default_currency, exchange = nil) : Money
-      new(0, currency, exchange)
+    def zero(currency = Money.default_currency) : Money
+      new(0, currency)
     end
 
     # Creates a new `Money` object of the given value, using the
@@ -50,8 +48,8 @@ struct Money
     # ```
     # Money.us_dollar(1_00) # => Money(@amount=1.0 @currency="USD")
     # ```
-    def us_dollar(value, exchange = nil) : Money
-      new(value, "USD", exchange)
+    def us_dollar(value) : Money
+      new(value, "USD")
     end
 
     # Creates a new `Money` object of the given value, using the
@@ -60,8 +58,8 @@ struct Money
     # ```
     # Money.euro(1_00) # => Money(@amount=1.0 @currency="EUR")
     # ```
-    def euro(value, exchange = nil) : Money
-      new(value, "EUR", exchange)
+    def euro(value) : Money
+      new(value, "EUR")
     end
 
     # Creates a new `Money` object of the given value, using the
@@ -70,8 +68,8 @@ struct Money
     # ```
     # Money.bitcoin(100) # => Money(@amount=0.000001 @currency="BTC")
     # ```
-    def bitcoin(value, exchange = nil) : Money
-      new(value, "BTC", exchange)
+    def bitcoin(value) : Money
+      new(value, "BTC")
     end
   end
 end

--- a/src/money/money/exchange.cr
+++ b/src/money/money/exchange.cr
@@ -9,7 +9,7 @@ struct Money
     # Money.new(1_00, "USD").exchange_to("EUR") # => Money(@amount=1.23, @currency="EUR")
     # Money.new(1_00, "EUR").exchange_to("USD") # => Money(@amount=0.82, @currency="USD")
     # ```
-    def exchange_to(other_currency : String | Symbol | Currency) : Money
+    def exchange_to(other_currency : String | Symbol | Currency, exchange = Money.default_exchange) : Money
       other_currency = Currency[other_currency]
       case
       when other_currency == currency


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Money no longer stores or exposes a per-instance exchange; exchange is managed via a global/default mechanism.
  - Constructors and parsing from strings/numbers no longer accept per-instance exchange parameters.

- New Features
  - Added a class-level mechanism to temporarily set the default exchange within a block.

- Tests
  - Test suite adjusted to remove per-instance exchange expectations and use the new default-exchange scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->