### PR TITLE
Add `Money.analyze`

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,16 @@ Money.parse("$12.34")    # => Money(@amount=12.34, @currency="USD")
 Money.parse("12.34 USD") # => Money(@amount=12.34, @currency="USD")
 ```
 
+There's also `Money.analyze` that returns an array of `Money` instances from a string:
+
+```crystal
+Money.analyze("$12.34")    # => [Money(@amount=12.34, @currency="USD"), ...]
+Money.analyze("12.34 USD") # => [Money(@amount=12.34, @currency="USD")]
+```
+
+> [!NOTE]
+> Returned `Money` instances are sorted by their currency priority.
+
 ## Contributors
 
 - [Sija](https://github.com/Sija) Sijawusz Pur Rahnama (creator & maintainer)

--- a/spec/money/parse_spec.cr
+++ b/spec/money/parse_spec.cr
@@ -1,6 +1,36 @@
 require "../spec_helper"
 
 describe Money::Parse do
+  describe ".analyze?" do
+    it "returns ambiguous values sorted by currency priority" do
+      moneys = Money.analyze?("$10").should_not be_nil
+      moneys.each do |money|
+        money.amount.should eq 10
+      end
+      moneys.map(&.currency.code).should eq %w[
+        USD AUD CAD ARS BBD BMD BND BSD BZD
+        CLP COP CUC CUP CVE DOP FJD GYD HKD
+        JMD KYD LRD MXN NAD NZD SBD SGD SRD
+        TTD TWD XCD ZWD ZWL ZWN ZWR
+      ]
+    end
+
+    it "returns unambiguous values as the single-value array" do
+      Money.analyze?("US$10").should eq [Money.from_amount(10.0, "USD")]
+      Money.analyze?("10 USD").should eq [Money.from_amount(10.0, "USD")]
+    end
+
+    it "returns nil when passed an invalid string" do
+      Money.analyze?("10+foo").should be_nil
+    end
+  end
+
+  describe ".analyze" do
+    it "raises when passed an invalid string" do
+      expect_raises(Money::Parse::Error) { Money.analyze("10+foo") }
+    end
+  end
+
   describe ".parse?" do
     it "parses symbol as prefix" do
       Money.parse?("$10").should eq Money.from_amount(10.0, "USD")

--- a/src/money/money/parse.cr
+++ b/src/money/money/parse.cr
@@ -86,6 +86,44 @@ struct Money
       end
     end
 
+    # Creates an array of `Money` instances from a string, or returns `nil` on failure.
+    #
+    # ```
+    # Money.analyze?("$10.00")   # => [Money(@amount=10.0, @currency="USD"), ...]
+    # Money.analyze?("US$10.00") # => [Money(@amount=10.0, @currency="USD")]
+    # ```
+    #
+    # See also `Money.parse?`.
+    def analyze?(str : String) : Array(Money)?
+      analyze(str) { nil }
+    end
+
+    # :ditto:
+    #
+    # NOTE: Raises `Money::Parse::Error` on failure instead of returning `nil`.
+    def analyze(str : String) : Array(Money)
+      analyze(str) { |ex| raise ex }
+    end
+
+    private def analyze(str : String, &)
+      amount, symbol = parse_amount_and_symbol(str)
+      currencies = parse_currencies(symbol)
+
+      if currencies.empty?
+        raise Error.new \
+          "Symbol #{symbol.inspect} didn't match any currency"
+      end
+
+      currencies.map do |currency|
+        Money.from_amount(
+          normalize_amount(amount, currency),
+          currency
+        )
+      end
+    rescue ex
+      yield Error.new "Cannot parse #{str.inspect}", ex
+    end
+
     private def parse_currencies(symbol : String) : Array(Currency)
       matcher = ->(str : String) do
         symbol.compare(str, case_insensitive: true).zero?


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIs to detect and parse all currency amounts found in a string.
  * Converted detected amounts into currency-specific money values.
  * Evaluated ambiguous amounts in currency-priority order.
  * Added optional parsing that returns no result for invalid input.
  * Added strict parsing that reports an error when input cannot be parsed.
  * Unambiguous input produces a single parsed money value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->